### PR TITLE
Add Python demos and improved UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This example demonstrates a minimal Django application **without** using a database. Messages are kept in memory using plain Python objects. It still highlights a few Django features:
 
-- Rendering templates with Bootstrap styling.
+- Rendering templates with Bootswatch styling.
 - Using Django forms for user input.
 - Basic view logic written in Python.
+- A small Python demo page with a random quote and factorial calculator.
 
 ## Quick start
 
@@ -16,3 +17,4 @@ python manage.py runserver
 ```
 
 Then open <http://localhost:8000/> in your browser.
+Navigate to <http://localhost:8000/demo/> to see the Python demo utilities.

--- a/hello/forms.py
+++ b/hello/forms.py
@@ -4,3 +4,11 @@ from django import forms
 class MessageForm(forms.Form):
     title = forms.CharField(max_length=100)
     content = forms.CharField(widget=forms.Textarea)
+
+
+class FactorialForm(forms.Form):
+    number = forms.IntegerField(
+        min_value=0,
+        max_value=12,
+        help_text="Enter a number between 0 and 12",
+    )

--- a/hello/templates/hello/base.html
+++ b/hello/templates/hello/base.html
@@ -3,16 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>{% block title %}Hello Django Codex{% endblock %}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
-    <div class="container-fluid">
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container">
         <a class="navbar-brand" href="{% url 'index' %}">Hello Django Codex</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="{% url 'index' %}">Home</a></li>
+                <li class="nav-item"><a class="nav-link" href="{% url 'utilities' %}">Python Demos</a></li>
+            </ul>
+        </div>
     </div>
 </nav>
 <div class="container">
     {% block content %}{% endblock %}
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/hello/templates/hello/index.html
+++ b/hello/templates/hello/index.html
@@ -4,11 +4,17 @@
 
 {% block content %}
 <h1 class="mb-4">Message Board</h1>
-<form method="post" class="mb-4">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="btn btn-primary">Post Message</button>
-</form>
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="post" class="row g-3">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <div class="text-end">
+                <button type="submit" class="btn btn-primary">Post Message</button>
+            </div>
+        </form>
+    </div>
+</div>
 <ul class="list-group">
     {% for msg in messages %}
     <li class="list-group-item">

--- a/hello/templates/hello/utilities.html
+++ b/hello/templates/hello/utilities.html
@@ -1,0 +1,30 @@
+{% extends 'hello/base.html' %}
+
+{% block title %}Python Demos{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Python Demos</h1>
+<div class="card mb-4">
+  <div class="card-header">Random Quote</div>
+  <div class="card-body">
+    <blockquote class="blockquote mb-0">{{ quote }}</blockquote>
+  </div>
+</div>
+<div class="card">
+  <div class="card-header">Factorial Calculator</div>
+  <div class="card-body">
+    <form method="post" class="row row-cols-lg-auto g-3 align-items-center">
+      {% csrf_token %}
+      <div class="col-12">
+        {{ form.number.label_tag }} {{ form.number }}
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Calculate</button>
+      </div>
+    </form>
+    {% if result is not None %}
+    <p class="mt-3">Result: {{ result }}</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/hello/urls.py
+++ b/hello/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('demo/', views.utilities, name='utilities'),
 ]

--- a/hello/views.py
+++ b/hello/views.py
@@ -1,10 +1,19 @@
 from dataclasses import dataclass
 from datetime import datetime
+import math
+import random
 from django.shortcuts import render, redirect
-from .forms import MessageForm
+from .forms import MessageForm, FactorialForm
 
 # In-memory list to store messages during runtime
 messages = []
+
+QUOTES = [
+    "Talk is cheap. Show me the code.",
+    "Simple is better than complex.",
+    "Errors should never pass silently.",
+    "Now is better than never.",
+]
 
 @dataclass
 class Message:
@@ -29,4 +38,22 @@ def index(request):
     return render(request, 'hello/index.html', {
         'form': form,
         'messages': messages,
+    })
+
+
+def utilities(request):
+    result = None
+    if request.method == 'POST':
+        form = FactorialForm(request.POST)
+        if form.is_valid():
+            number = form.cleaned_data['number']
+            result = math.factorial(number)
+    else:
+        form = FactorialForm()
+
+    quote = random.choice(QUOTES)
+    return render(request, 'hello/utilities.html', {
+        'form': form,
+        'result': result,
+        'quote': quote,
     })


### PR DESCRIPTION
## Summary
- provide Bootswatch styling and navigation links
- show messages using cards
- add FactorialForm and utilities page for Python demos
- offer random quotes and factorial calculator
- document new demo page in README

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843fef577708331a0acf0701f60cd9a