### PR TITLE
Fix CSRF origin error

### DIFF
--- a/helloworld/settings.py
+++ b/helloworld/settings.py
@@ -53,3 +53,10 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Allow deployments like Azure App Service to specify additional trusted origins
+CSRF_TRUSTED_ORIGINS = os.environ.get(
+    'CSRF_TRUSTED_ORIGINS',
+    'http://localhost,https://*.azurewebsites.net'
+).split(',')
+


### PR DESCRIPTION
## Summary
- allow configurable CSRF_TRUSTED_ORIGINS via environment variable

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844047900ac8331a1edfe6212083eda