### PR TITLE
Fix panic records template error

### DIFF
--- a/hello/templates/hello/panic_records.html
+++ b/hello/templates/hello/panic_records.html
@@ -18,7 +18,7 @@
     <tbody>
         {% for item in page_obj %}
         <tr>
-            <td>{{ item['RowKey'] }}</td>
+            <td>{{ item.RowKey }}</td>
             <td><pre class="mb-0">{{ item }}</pre></td>
         </tr>
         {% empty %}


### PR DESCRIPTION
## Summary
- fix list indexing in panic_records template

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684412f0c1c483318e36767f79cb47a4