### PR TITLE
Fix missing static tag

### DIFF
--- a/hello/templates/hello/dino.html
+++ b/hello/templates/hello/dino.html
@@ -1,4 +1,5 @@
 {% extends 'hello/base.html' %}
+{% load static %}
 
 {% block title %}Chrome Dino{% endblock %}
 


### PR DESCRIPTION
## Summary
- load the static template tags in dino.html so Phaser images can load

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68443db28b448331b84a86427f352008